### PR TITLE
Delete user and Edit by Manager

### DIFF
--- a/project/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/project/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -48,41 +48,44 @@ class RegisteredUserController extends Controller
      */
     public function store(Request $request): RedirectResponse
     {
-        $request->validate([
-            'name' => ['required'],
-            'surname' => ['required'],
-            'role' => [ 'required' ],
-            'facility' => ['required'],
-            'email' => ['required', 'string', 'max:255', 'unique:'.User::class, 'regex:/^.+@.+$/'],#Rule::unique('users', 'email')
-            'password' => ['required',
-                'regex:/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#\$%\^&\*])(?=.{8,})/'],//Rules\Password::defaults()],
-            'repeat_password' => ['required', 'same:password']
-        ]);
-/*
-        $validator = Validator::make($request->all(), [
-            'name' => ['required'],
-            'email' => ['required', 'email', 'unique:users'],
-            'password' => ['required', 'min:8', 'confirmed'],
-        ]);
-
-        $validator->messages()->add('email.unique', 'This email address is already in use.');
-
-        if ($validator->fails()) {
-            return redirect('register')
-                ->withErrors($validator)
-                ->withInput();
+        if( Auth::user()->role == 1 ){
+            $request->validate([
+                'name' => ['required'],
+                'surname' => ['required'],
+                'role' => [ 'required' ],
+                'facility' => ['required'],
+                'email' => ['required', 'string', 'max:255', 'unique:'.User::class, 'regex:/^.+@.+$/'],#Rule::unique('users', 'email')
+                'password' => ['required',
+                    'regex:/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#\$%\^&\*])(?=.{8,})/'],//Rules\Password::defaults()],
+                'repeat_password' => ['required', 'same:password']
+            ]);
+        } else{
+            $request->validate([
+                'name' => ['required'],
+                'surname' => ['required'],
+                'role' => [ 'required' ],
+                'email' => ['required', 'string', 'max:255', 'unique:'.User::class, 'regex:/^.+@.+$/'],#Rule::unique('users', 'email')
+                'password' => ['required',
+                    'regex:/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#\$%\^&\*])(?=.{8,})/'],//Rules\Password::defaults()],
+                'repeat_password' => ['required', 'same:password']
+            ]);
         }
-*/
+
         $user = new User();
         $user->name = $request->name;
         $user->surname = $request->surname;
         $user->email =  $request->email;
         $user->password =  Hash::make(strval($request['password']));
         $user->role = $request->role;
-        $user->facility = $request->facility;
+        if( Auth::user()->role == 1 ){
+            $user->facility = $request->facility;
+        } else{
+            $user->facility = Auth::user()->facility;
+        }
+
         $user->save();
 
-        return Redirect::to('/');
+        return Redirect::to('/allusers');
     }
 
     public function edituser(int $id): View
@@ -93,13 +96,21 @@ class RegisteredUserController extends Controller
 
     public function update(Request $request, int $id): RedirectResponse
     {
+        if (Auth::user()->role == 1) {
+            $request->validate([
+                'name' => ['required'],
+                'surname' => ['required'],
+                'role' => ['required'],
+                'facility' => ['required'],
+            ]);
+        } else{
+            $request->validate([
+                'name' => ['required'],
+                'surname' => ['required'],
+                'role' => ['required'],
+            ]);
+        }
 
-        $request->validate([
-            'name' => ['required'],
-            'surname' => ['required'],
-            'role' => [ 'required' ],
-            'facility' => ['required'],
-        ]);
 
         $user = User::find($id);
         if ($user != null) {
@@ -107,10 +118,22 @@ class RegisteredUserController extends Controller
             $user->surname = $request->surname;
             $user->email = $request->email;
             $user->role = $request->role;
-            $user->facility = $request->facility;
+            if (Auth::user()->role == 1) {
+                $user->facility = $request->facility;
+            }
             $user->save();
         }
-
-        return Redirect::to('/');
+        return Redirect::to('/allusers');
     }
+
+    public function delete(Request $request, int $id): RedirectResponse
+    {
+        $user = User::find($id);
+        if ($user!= null) {
+            $user->delete();
+        }
+        return Redirect::to('/allusers');
+    }
+
+
 }

--- a/project/app/Http/Middleware/EnsureAdmin.php
+++ b/project/app/Http/Middleware/EnsureAdmin.php
@@ -17,7 +17,7 @@ class EnsureAdmin
      */
     public function handle(Request $request, Closure $next)
     {
-        if (Auth::check() && Auth::user()->role == 1) {
+        if (Auth::check() && ( Auth::user()->role == 1 || Auth::user()->role == 2  ) ) {
             return $next($request);
         }
 

--- a/project/database/seeders/UsersSeeder.php
+++ b/project/database/seeders/UsersSeeder.php
@@ -28,5 +28,13 @@ class UsersSeeder extends Seeder
             'role'=>2, //2 = kierownik
             'facility' => 2
         ]);
+        DB::table('users')->insert([
+            'name' => 'Adam',
+            'surname' => 'Doe',
+            'email' => 'adam.doe@email.com',
+            'password' => bcrypt('adamdoe'),
+            'role'=>4, //2 = kierownik
+            'facility' => 2
+        ]);
     }
 }

--- a/project/resources/views/auth/allusers.blade.php
+++ b/project/resources/views/auth/allusers.blade.php
@@ -24,6 +24,7 @@
                     </thead>
                     <tbody class="bg-white divide-y divide-gray-200">
                     @foreach ($users as $user)
+                        @if( (Auth::user()->role == 1  && $user->role != 1)||  (Auth::user()->role == 2 &&  Auth::user()->facility == $user->facility && $user->role != 2 && $user->role != 1))
                         <tr>
                             <td class="px-6 py-4">
                                 <a href="{{ url("edituser", $user->id) }}" class="text-indigo-600 hover:text-indigo-900">
@@ -39,6 +40,7 @@
                                     {{ $user->email }}
                             </td>
                         </tr>
+                        @endif
                     @endforeach
                     </tbody>
                 </table>

--- a/project/resources/views/auth/edituser.blade.php
+++ b/project/resources/views/auth/edituser.blade.php
@@ -24,6 +24,7 @@
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
 
+        @if( Auth::user()->role == 1 )
         <!-- Facility -->
         <div>
             <label for="facility">Placówka:</label>
@@ -38,14 +39,16 @@
             </select>
             <x-input-error :messages="$errors->get('facility')" class="mt-2" />
         </div>
-
+        @endif
         <!-- Role -->
         <div>
             <label for="role">Rola:</label>
             <select name="role" id="role">
                 <option value="">--- Wybierz rolę ---</option>
                 <!-- <option value=1 selected>Admin</option> -->
+                @if( Auth::user()->role == 1 )
                 <option value=2 {{ $user->role == 2 ? 'selected' : '' }}>Kierownik</option>
+                @endif
                 <option value=3 {{ $user->role == 3 ? 'selected' : '' }}>Pracownik</option>
                 <option value=4 {{ $user->role == 4 ? 'selected' : '' }}>Księgowy</option>
                 <option value=5 {{ $user->role == 5 ? 'selected' : '' }}>Magazynier</option>
@@ -57,6 +60,14 @@
         <div class="flex items-center justify-end mt-4">
             <x-primary-button class="ml-4">
                 {{ __('Edytuj konto') }}
+            </x-primary-button>
+        </div>
+    </form>
+    <form action="{{url("delete", $user->id)}}" method="POST">
+        @csrf
+        <div class="flex items-center justify-end mt-4">
+            <x-primary-button class="ml-4 bg-red-500 hover:bg-red-600">
+                {{ __('Usuń') }}
             </x-primary-button>
         </div>
     </form>

--- a/project/resources/views/auth/register.blade.php
+++ b/project/resources/views/auth/register.blade.php
@@ -23,6 +23,7 @@
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
 
+        @if( Auth::user()->role == 1 )
         <!-- Facility -->
         <div>
             <x-input-label for="placówka" :value="__('Placówka')" />
@@ -36,6 +37,7 @@
             </select>
             <x-input-error :messages="$errors->get('facility')" class="mt-2" />
         </div>
+        @endif
 
         <!-- Role -->
         <div>
@@ -43,7 +45,9 @@
             <select name="role" id="role">
                 <option value="">--- Wybierz rolę ---</option>
                 <!-- <option value=1 selected>Admin</option> -->
-                <option value=2>Kierownik</option>
+                @if( Auth::user()->role == 1 )
+                    <option value=2 >Kierownik</option>
+                @endif
                 <option value=3>Pracownik</option>
                 <option value=4>Księgowy</option>
                 <option value=5>Magazynier</option>

--- a/project/resources/views/layouts/navigation.blade.php
+++ b/project/resources/views/layouts/navigation.blade.php
@@ -16,7 +16,7 @@
                         {{ __('Strona główna') }}
                     </x-nav-link>
                 </div>
-                @if (Auth::check() && Auth::user()->role == 1)
+                @if (Auth::check() && ( Auth::user()->role == 1 ||  Auth::user()->role == 2))
                 <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
                     <x-nav-link :href="route('schedules')" :active="request()->routeIs('auth.schedules')">
                         {{ __('Harmonogramy') }}

--- a/project/routes/web.php
+++ b/project/routes/web.php
@@ -57,6 +57,7 @@ Route::middleware(['admin'])->group(function () {
     Route::get('allusers', [\App\Http\Controllers\Auth\RegisteredUserController::class, "allusers"])->name("allusers");
     Route::get('edituser/{id}', [\App\Http\Controllers\Auth\RegisteredUserController::class, "edituser"])->name("edituser");
     Route::post('update/{id}', [\App\Http\Controllers\Auth\RegisteredUserController::class, "update"])->name("update");
+    Route::post('delete/{id}', [\App\Http\Controllers\Auth\RegisteredUserController::class, "delete"])->name("delete");
 
 });
 


### PR DESCRIPTION
Zmieniony został Middleware EnsureAdmin, żeby dopuszczał kierownika. Kierownik może zarejestrować, edytować i usunąć pracownika tylko w swojej placówce. W widoku allusers kierownik może widzieć tylko pracowników w swojej placówce. Zostały dodane odpowiednie zmiany w widokach - ograniczające akcje kierownika - nie może on wybierać placówki lub tworzyć użytkownika w roli kierownika. Admin dostał dodatkową możliwość usuwania użytkowników.