### PR TITLE
Edit delete tests

### DIFF
--- a/project/tests_codeception/Acceptance/Test09_AdminDeletesUsersCest.php
+++ b/project/tests_codeception/Acceptance/Test09_AdminDeletesUsersCest.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace TestsCodeception\Acceptance;
+
+use TestsCodeception\Support\AcceptanceTester;
+
+class Test09_AdminDeletesUsersCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+        $I->haveInDatabase('users', array('name' => "Agent", 'surname' => "Smith", 'email' => "agentS@mail.com",
+            'password' => hash('md5', 'NULL'), 'role' => 2, 'facility' => 1));
+        $I->haveInDatabase('users', array('name' => "John", 'surname' => "Smith", 'email' => "johnyy@email.com",
+            'password' => hash('md5', 'janek'), 'role' => 3, 'facility' => 2));
+    }
+
+    // tests
+    public function tryToTest(AcceptanceTester $I)
+    {
+        $I->wantTo('Admin deletes users');
+
+        $I->amOnPage("/");
+
+        $I->seeInDatabase('users', ['role' => "1"]);
+
+        $I->fillField("email", "first.name@email.com");
+        $I->fillField("password", "first");
+        $I->click("Zaloguj się");
+
+        $I->amOnPage('/allusers');
+        $I->see("Agent");
+        $I->see("John");
+
+        $I->seeInDatabase("users", ['name' => "John", 'email' => 'johnyy@email.com']);
+        $I->seeInDatabase("users", ['name' => "Agent", 'email' => 'agentS@mail.com']);
+        $I->click("John");
+        $I->click("Usuń");
+        $I->dontSeeInDatabase("users", ['name' => "John", 'email' => 'johnyy@email.com']);
+        $I->seeInDatabase("users", ['name' => "Agent", 'email' => 'agentS@mail.com']);
+
+        $I->seeCurrentUrlEquals("/allusers");
+        $I->see("Agent");
+        $I->dontSee("John");
+    }
+}

--- a/project/tests_codeception/Acceptance/Test10_ManagerDeletesUsersCest.php
+++ b/project/tests_codeception/Acceptance/Test10_ManagerDeletesUsersCest.php
@@ -1,0 +1,51 @@
+<?php
+
+
+namespace TestsCodeception\Acceptance;
+
+use TestsCodeception\Support\AcceptanceTester;
+
+class Test10_ManagerDeletesUsersCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+        $I->haveInDatabase('users', array('name' => "Agent", 'surname' => "Smith", 'email' => "agentS@mail.com",
+            'password' => password_hash('NULL', PASSWORD_DEFAULT), 'role' => 2, 'facility' => 1));
+
+        $id1 = $I->haveInDatabase('users', array('name' => "John", 'surname' => "Smith", 'email' => "johnyy@email.com",
+            'password' => hash('md5', 'janek'), 'role' => 3, 'facility' => 2));
+        $I->haveInDatabase('users', array('name' => "Alice", 'surname' => "Smith", 'email' => "alice@email.com",
+            'password' => hash('md5', 'myPassword'), 'role' => 3, 'facility' => 1));
+        $I->haveInDatabase('users', array('name' => "Bob", 'surname' => "Smith", 'email' => "bob@email.com",
+            'password' => hash('md5', 'imbob'), 'role' => 3, 'facility' => 1));
+    }
+
+    // tests
+    public function tryToTest(AcceptanceTester $I)
+    {
+        $I->wantTo('Manager deletes their users');
+
+        $I->amOnPage("/");
+
+        $I->fillField("email", "agentS@mail.com");
+        $I->fillField("password", "NULL");
+        $I->click("Zaloguj się");
+
+        $I->amOnPage('/allusers');
+        $I->seeInDatabase("users", ['name' => "John", 'email' => 'johnyy@email.com']);
+        $I->seeInDatabase("users", ['name' => "Alice", 'email' => 'alice@email.com']);
+        $I->seeInDatabase("users", ['name' => "Bob", 'email' => 'bob@email.com']);
+        $I->see("Alice");
+        $I->see("Bob");
+        //$I->dontSee("John");
+
+        $I->click("Alice");
+        $I->click("Usuń");
+        $I->dontSeeInDatabase("users", ['name' => "Alice", 'email' => 'alice@email.com']);
+        $I->seeInDatabase("users", ['name' => "Bob", 'email' => 'bob@email.com']);
+
+        $I->seeCurrentUrlEquals("/allusers");
+        $I->see("Bob");
+        $I->dontSee("Alice");
+    }
+}

--- a/project/tests_codeception/Acceptance/Test11_ManagerEditsUsersCest.php
+++ b/project/tests_codeception/Acceptance/Test11_ManagerEditsUsersCest.php
@@ -1,0 +1,65 @@
+<?php
+
+
+namespace TestsCodeception\Acceptance;
+
+use TestsCodeception\Support\AcceptanceTester;
+
+class Test11_ManagerEditsUsersCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+        $I->haveInDatabase('users', array('name' => "Agent", 'surname' => "Smith", 'email' => "agentS@mail.com",
+            'password' => password_hash('NULL', PASSWORD_DEFAULT), 'role' => 2, 'facility' => 1));
+
+        $I->haveInDatabase('users', array('name' => "Alice", 'surname' => "Smith", 'email' => "alice@email.com",
+            'password' => hash('md5', 'myPassword'), 'role' => 3, 'facility' => 1));
+        $I->haveInDatabase('users', array('name' => "Bob", 'surname' => "Smith", 'email' => "bob@email.com",
+            'password' => hash('md5', 'imbob'), 'role' => 3, 'facility' => 1));
+    }
+
+    // tests
+    public function tryToTest(AcceptanceTester $I)
+    {
+        $id1 = $I->haveInDatabase('users', array('name' => "John", 'surname' => "Smith", 'email' => "johnyy@email.com",
+            'password' => hash('md5', 'janek'), 'role' => 3, 'facility' => 2));
+        $I->wantTo('Manager edits their users');
+
+        $I->amOnPage("/");
+
+        $I->fillField("email", "agentS@mail.com");
+        $I->fillField("password", "NULL");
+        $I->click("Zaloguj się");
+
+        $I->amOnPage('/allusers');
+        $I->seeInDatabase("users", ['name' => "John", 'email' => 'johnyy@email.com']);
+        $I->seeInDatabase("users", ['name' => "Alice", 'email' => 'alice@email.com']);
+        $I->seeInDatabase("users", ['name' => "Bob", 'email' => 'bob@email.com']);
+        $I->see("Alice");
+        $I->see("Bob");
+        //$I->dontSee("John");
+
+        $I->click("Bob");
+        $I->dontSee("Placówka");
+        $I->see("Rola");
+
+        $I->fillField("name", "Grzegorz");
+        $I->fillField("surname", "Nowak");
+        $I->fillField("email", "gnowak@mail.com");
+        $I->selectOption('role', "Magazynier");
+        $I->click("Edytuj konto");
+
+        $I->seeCurrentUrlEquals("/allusers");
+
+        $I->seeInDatabase("users", ['name' => "John", 'email' => 'johnyy@email.com']);
+        $I->seeInDatabase("users", ['name' => "Alice", 'email' => 'alice@email.com']);
+        $I->dontSeeInDatabase("users", ['name' => "Bob", 'email' => 'bob@email.com']);
+        $I->seeInDatabase("users", ['name' => "Grzegorz", 'surname' => "Nowak", 'email' => 'gnowak@mail.com',
+            'role' => "5", 'facility' => "1"]);
+        $I->see("Grzegorz");
+        $I->see("Nowak");
+
+        $I->amOnPage("/edituser/".$id1);
+        $I->seeCurrentUrlEquals("/");
+    }
+}


### PR DESCRIPTION
Dodałem testy do GL-45, -46, -31. Wszystko działa poprawnie poza ostatnim testem, który wysypuje się na tym, o czym wspominał Adam - jeżeli ograniczaliśmy dostęp do użytkowników np. kierownika, to robiliśmy to jedynie za pomocą filtrowania wyświetlania. Jeżeli kierownik ręcznie zmieni URL, to może się dostać do dowolnego użytkownika. Trzebaby to naprawić w kolejnym sprincie jako rzeczywiście ustawienia widoków / zakresu dostępności.